### PR TITLE
apply apiserver defaults

### DIFF
--- a/cmd/generate-crd-api/main_test.go
+++ b/cmd/generate-crd-api/main_test.go
@@ -106,6 +106,23 @@ func TestGenerateCrdApiE2E(t *testing.T) {
 			wantErrMsg: "failed to parse CRDs",
 		},
 		{
+			name: "missing_list_kind_defaults_to_kind_list",
+			args: []string{"--crd", filepath.Join(testdata, "no-listkind.testing.crd-gen.yaml")},
+			expectedFiles: []string{
+				"v1/group_version_info.go",
+				"v1/types_nolistkind.go",
+			},
+			fileContentChecks: map[string][]string{
+				"v1/types_nolistkind.go": {
+					"type NoListKind struct {",
+					"type NoListKindList struct {",
+				},
+				"v1/group_version_info.go": {
+					"SchemeBuilder.Register(&NoListKind{}, &NoListKindList{})",
+				},
+			},
+		},
+		{
 			name: "all_cases",
 			args: []string{"--crd", filepath.Join(testdata, "all-cases.testing.crd-gen.yaml")},
 			expectedFileGolden: map[string]string{

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -182,7 +182,9 @@ func (r *CustomResources) parseCRD(crdData []byte, desiredVersion string) (*Cust
 	if err != nil {
 		return nil, err
 	}
-	// Extract CRD info
+	// Apply the same defaulting the Kubernetes API server does so an unset
+	// listKind defaults to <Kind>List.
+	apiv1.SetObjectDefaults_CustomResourceDefinition(&crd)
 
 	// Extract schema
 	schema, version, err := extractSchemas(crd, desiredVersion)

--- a/testdata/no-listkind.testing.crd-gen.yaml
+++ b/testdata/no-listkind.testing.crd-gen.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nolistkinds.testing.crd-gen
+spec:
+  group: testing.crd-gen
+  names:
+    # listKind is intentionally omitted to verify it defaults to <Kind>List.
+    kind: NoListKind
+    plural: nolistkinds
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                stringField:
+                  type: string
+                  description: "A simple string field"


### PR DESCRIPTION
The new Crossplane CLI provides `crossplane xrd convert`, which converts a Crossplane XRD to CRD. However it does not contain a `listKind` definition, which breaks the Go type generation. The apiserver defaults `listKind: <kind>List` by default if it is not set. 